### PR TITLE
GDB-10775: GraphDB Single VM GCP Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# IDEs
+.idea/
+
+# Certificates
+*.pem
+*.p12
+*.pub
+
+# Licenses
+*.license
+
+# Deployment package
+*.zip

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.0.1"
+  constraints = "6.0.1"
+  hashes = [
+    "h1:PcFIs2OUrYBSzcNqMgRLtjfyQVDnlvOENt+/vCHOYuI=",
+    "zh:053bcc0e62396d10a4ef40e59dcdf7d4a1491839e0dfc945de7cef5d9106a566",
+    "zh:282624e6dd086dfe10281f6ad6def3b64279e69fbd667d1141c5f1565e42aecf",
+    "zh:633384cc00d1c6e84b6cb302a898a407c85806a818ca2c93989992b4f9e9af99",
+    "zh:7099aa1a79594c6e041659e36a48f0134a19bd8e1810dfddc21bbad6d3e36d54",
+    "zh:8259adb345c1563a64bdc58efd1cae2ff174b518ccb1f31f79c9c5825e7f762e",
+    "zh:ae2c3008fe93a3bc1318079c23b1da9b55a77ace45f18cf0fa3b2aefcf33e94a",
+    "zh:b7f17cb09b4636edf4aed68ab224885523bd33a0b50af2a2a2819d5a843d49e9",
+    "zh:bee71d0adb8b842b812e4fc76853bedec93c17a6cbf56bc502a2ecf0bcbdaf98",
+    "zh:c187e22fa33cfa90a093cd25e61a77fb88898cce3f79bef33392ddb7708724ca",
+    "zh:dd5923c79697be9429edb98156aa94e69b7258f8de42d8c910dde6814c1ef981",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe789dc52fc029c18e92db0efb3b013d15679b81c1ab633fa69b3eacde9842ac",
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+VERSION := $(shell echo "var.source_image" | terraform console | grep -oP 'graphdb-\K[0-9]+-[0-9]+-[0-9]+')
+
+# Name of the output zip file
+ZIP_NAME := "graphdb-single-vm-deployment-package-${VERSION}.zip"
+
+# Default target to create the zip
+all: package
+
+# Rule to create the zip file
+package: clean
+	zip -r $(ZIP_NAME) *.tf *.yaml LICENSE README.md
+
+# Clean target to remove the zip file
+clean:
+	rm -f $(ZIP_NAME)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# gcp-deployment-package
+# GraphDB deployment package on GCP
+
+## Quickstart
+
+```shell
+terraform init
+terraform apply
+```
+
+Additionally, to specify custom values for the variables, you can use a `.tfvars` file, or specify individual
+variables on the command line, e.g. `-var project_id=<test-project>`.
+
+## Metadata
+
+To update and validate the [metadata.yaml](metadata.yaml) and [metadata.display.yaml](metadata.display.yaml) you can use Google's CFT
+tool https://pkg.go.dev/github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata
+
+Run the following command in the project directory to regenerate the metadata:
+
+```bash
+cft blueprint metadata -d -p .
+```
+
+Or simply to validate:
+
+```bash
+cft blueprint metadata -v -p .
+```
+
+## Resources
+
+- Examples for configuring Blueprint metadata
+  - https://github.com/GoogleCloudPlatform/marketplace-tools/blob/master/examples/terraform/wordpress/metadata.display.yaml
+  - https://github.com/g-awmalik/terraform-google-canonical-mp/blob/main/metadata.display.yaml
+- Blueprint reference https://pkg.go.dev/github.com/GoogleCloudPlatform/cloud-foundation-toolkit/cli/bpmetadata

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,42 @@
+provider "google" {
+  project = var.project_id
+}
+
+resource "google_compute_instance" "graphdb" {
+  name         = var.goog_cm_deployment_name
+  machine_type = var.machine_type
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      # The boot disk must be set to the variable declared in Producer Portal
+      image = var.source_image
+      size  = var.boot_disk_size
+      type = var.boot_disk_type
+    }
+  }
+
+  network_interface {
+    network = var.network_interface
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  tags = [var.goog_cm_deployment_name]
+}
+
+resource "google_compute_firewall" "rules" {
+  name        = "graphdb-allow-ingress"
+  network     = var.network_interface
+  description = "Allow inbound access to GraphDB"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["7200"]
+  }
+
+  source_ranges = var.allowed_ingress_cidrs
+  target_tags   = [var.goog_cm_deployment_name]
+}

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -1,0 +1,78 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: graphdb-single-vm-display
+  annotations:
+    autogenSpecType: SINGLE_VM
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: GraphDB deployment package on GCP
+    source:
+      repo: https://github.com/Ontotext-AD/gcp-deployment-package-graphdb.git
+      sourceType: git
+      dir: /
+  ui:
+    input:
+      variables:
+        allowed_ingress_cidrs:
+          name: allowed_ingress_cidrs
+          title: Allowed Ingress CIDRs
+          section: networking
+        boot_disk_size:
+          name: disk_size
+          title: Disk Size
+          section: boot_disk
+          xGoogleProperty:
+            type: ET_GCE_DISK_SIZE
+            gceDiskSize:
+              diskTypeVariable: boot_disk_type
+        boot_disk_type:
+          name: boot_disk_type
+          title: Boot Disk Type
+          section: boot_disk
+          xGoogleProperty:
+            type: ET_GCE_DISK_TYPE
+            zoneProperty: zone
+        goog_cm_deployment_name:
+          name: goog_cm_deployment_name
+          title: Goog Cm Deployment Name
+        machine_type:
+          name: machine_type
+          title: Machine Type
+          xGoogleProperty:
+            type: ET_GCE_MACHINE_TYPE
+            zoneProperty: zone
+        name:
+          name: name
+          title: Name
+        network_interface:
+          name: network_interface
+          title: Network Interface
+          section: networking
+          xGoogleProperty:
+            type: ET_GCE_NETWORK
+            gceNetwork:
+              allowSharedVpcs: true
+              machineTypeVariable: machine_type
+        project_id:
+          name: project_id
+          title: Project Id
+        source_image:
+          name: source_image
+          title: Image version
+          invisible: true
+          xGoogleProperty:
+            type: ET_GCE_DISK_IMAGE
+        zone:
+          name: zone
+          title: Zone
+          xGoogleProperty:
+            type: ET_GCE_ZONE
+      sections:
+        - name: networking
+          title: Networking
+          tooltip: Networking related configurations
+        - name: boot_disk
+          title: Boot Disk
+          tooltip: Configure the boot disk for GraphDB

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,63 @@
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: graphdb-single-vm
+  annotations:
+    autogenSpecType: SINGLE_VM
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: GraphDB deployment package on GCP
+    source:
+      repo: https://github.com/Ontotext-AD/gcp-deployment-package-graphdb.git
+      sourceType: git
+      dir: /
+    description: {}
+  content:
+    documentation:
+      - title: GraphDB Documentation
+        url: https://graphdb.ontotext.com/documentation/
+  interfaces:
+    variables:
+      - name: allowed_ingress_cidrs
+        description: CIDR blocks that are allowed to access the GraphDB port
+        varType: list(string)
+        defaultValue:
+          - 0.0.0.0/0
+      - name: boot_disk_size
+        description: Boot disk size in GBs
+        varType: number
+        defaultValue: 500
+      - name: boot_disk_type
+        description: Type of the boot disk
+        varType: string
+        defaultValue: pd-ssd
+      - name: goog_cm_deployment_name
+        description: Deployment name
+        varType: string
+        defaultValue: graphdb
+      - name: machine_type
+        description: Type of the VM that will be created
+        varType: string
+        defaultValue: n2-highmem-8
+      - name: network_interface
+        description: The network interface to attach the VM to
+        varType: string
+        defaultValue: default
+      - name: project_id
+        description: Project in which the VM will be created
+        varType: string
+        required: true
+      - name: source_image
+        description: Defines the VM image passed from the GCP Marketplace
+        varType: string
+        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-10-7-3-202409031355
+      - name: zone
+        description: The zone where the VM will be created
+        varType: string
+        defaultValue: us-central1-a
+    outputs:
+      - name: graphdb_address
+        description: External URL address for accessing GraphDB
+      - name: instance_ip
+        description: External IP address for the GraphDB VM instance

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,14 @@
+locals {
+  network_interface = google_compute_instance.graphdb.network_interface[0]
+  instance_nat_ip   = length(local.network_interface.access_config) > 0 ? local.network_interface.access_config[0].nat_ip : null
+}
+
+output "instance_ip" {
+  description = "External IP address for the GraphDB VM instance"
+  value       =  local.instance_nat_ip
+}
+
+output "graphdb_address" {
+  description = "External URL address for accessing GraphDB"
+  value       = "http://${local.instance_nat_ip}:7200"
+}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "6.0.1"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,56 @@
+# The variable "image" is declared in Producer Portal
+
+variable "source_image" {
+  description = "Defines the VM image passed from the GCP Marketplace"
+  type        = string
+  # Set the default value to your image. Marketplace will overwrite this value
+  # to a Marketplace owned image on publishing the product
+  default = "projects/graphdb-public/global/images/ontotext-graphdb-10-7-3-202409031355"
+}
+
+variable "goog_cm_deployment_name" {
+  description = "Deployment name"
+  type        = string
+  default     = "graphdb"
+}
+
+variable "project_id" {
+  description = "Project in which the VM will be created"
+  type        = string
+}
+
+variable "zone" {
+  description = "The zone where the VM will be created"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "machine_type" {
+  description = "Type of the VM that will be created"
+  type        = string
+  default     = "n2-highmem-8"
+}
+
+variable "boot_disk_size" {
+  description = "Boot disk size in GBs"
+  type        = number
+  default     = 500
+}
+
+variable "boot_disk_type" {
+  description = "Type of the boot disk"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "network_interface" {
+  description = "The network interface to attach the VM to"
+  type        = string
+  default     = "default"
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks that are allowed to access the GraphDB port"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
- Added Terraform module for deployment in GCP Compute Engine
- Added Google Blueprint metadata YAMLs that guide the launching in GCP
- Added Makefile for easily packaging the deployment ZIP