### PR TITLE
GDB-12470: Update GraphDB to version 10.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.7
+
+* Updated to GraphDB [10.8.8](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-8)
+
 ## 0.2.6
 
 * Updated to GraphDB [10.8.7](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-7)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,7 +51,7 @@ spec:
       - name: source_image
         description: Defines the VM image passed from the GCP Marketplace
         varType: string
-        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-10-8-7-202505280754
+        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-10-8-8-202506050741
       - name: zone
         description: The zone where the VM will be created
         varType: string

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "source_image" {
   type        = string
   # Set the default value to your image. Marketplace will overwrite this value
   # to a Marketplace owned image on publishing the product
-  default = "projects/graphdb-public/global/images/ontotext-graphdb-10-8-7-202505280754"
+  default = "projects/graphdb-public/global/images/ontotext-graphdb-10-8-8-202506050741"
 }
 
 variable "goog_cm_deployment_name" {


### PR DESCRIPTION
- Updated the Terraform do deploy the latest version of the VM image for 10.x
- Updated the blueprints