### PR TITLE
GDB-12439: Update GraphDB to version 11.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+* Update default GraphDB version to [11.0.2](https://graphdb.ontotext.com/documentation/11.0/release-notes.html#graphdb-11-0-2)
+
 ## 0.3.1
 
 * Update default GraphDB version to [11.0.1](https://graphdb.ontotext.com/documentation/11.0/release-notes.html#graphdb-11-0-1)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ versions. The next table shows the version compatability between GraphDB, and th
 
 | GraphDB Terraform                                                              | GraphDB                                                                              |
 |--------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| [Version 0.1.x](https://github.com/Ontotext-AD/terraform-gcp-graphdb/releases)  | [Version 10.7.x](https://graphdb.ontotext.com/documentation/10.7/release-notes.html) |
+| [Version 0.1.x](https://github.com/Ontotext-AD/terraform-gcp-graphdb/releases) | [Version 10.7.x](https://graphdb.ontotext.com/documentation/10.7/release-notes.html) |
 | [Version 0.2.x](https://github.com/Ontotext-AD/terraform-gcp-graphdb/releases) | [Version 10.8.x](https://graphdb.ontotext.com/documentation/10.8/release-notes.html) |
+| [Version 0.3.x](https://github.com/Ontotext-AD/terraform-gcp-graphdb/releases) | [Version 11.0.x](https://graphdb.ontotext.com/documentation/11.0/release-notes.html) |
 You can track the particular version updates of GraphDB in the [changelog](CHANGELOG.md).
 
 ## Prerequisites

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| source\_image | Defines the VM image passed from the GCP Marketplace | `string` | `"projects/graphdb-public/global/images/ontotext-graphdb-11-0-1-202504301455"` | no |
+| source\_image | Defines the VM image passed from the GCP Marketplace | `string` | `"projects/graphdb-public/global/images/ontotext-graphdb-11-0-2-202507031100"` | no |
 | goog\_cm\_deployment\_name | Deployment name | `string` | `"graphdb"` | no |
 | project\_id | Project in which the VM will be created | `string` | n/a | yes |
 | zone | The zone where the VM will be created | `string` | `"us-central1-a"` | no |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,7 +51,7 @@ spec:
       - name: source_image
         description: Defines the VM image passed from the GCP Marketplace
         varType: string
-        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-11-0-1-202504301455
+        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-11-0-2-202507031100
       - name: zone
         description: The zone where the VM will be created
         varType: string

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "source_image" {
   type        = string
   # Set the default value to your image. Marketplace will overwrite this value
   # to a Marketplace owned image on publishing the product
-  default = "projects/graphdb-public/global/images/ontotext-graphdb-11-0-1-202504301455"
+  default = "projects/graphdb-public/global/images/ontotext-graphdb-11-0-2-202507031100"
 }
 
 variable "goog_cm_deployment_name" {


### PR DESCRIPTION
- Updated the Terraform do deploy the latest version of the VM image for 11.x
- Updated the blueprints
