### PR TITLE
GDB-12672: Update GraphDB version to 10.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.8
+
+* Updated to GraphDB [10.8.9](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-9)
+
 ## 0.2.7
 
 * Updated to GraphDB [10.8.8](https://graphdb.ontotext.com/documentation/10.8/release-notes.html#graphdb-10-8-8)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Before you begin using this Terraform module, ensure you meet the following prer
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| source\_image | Defines the VM image passed from the GCP Marketplace | `string` | `"projects/graphdb-public/global/images/ontotext-graphdb-10-8-8-202506050741"` | no |
+| source\_image | Defines the VM image passed from the GCP Marketplace | `string` | `"projects/graphdb-public/global/images/ontotext-graphdb-10-8-9-202507160729"` | no |
 | goog\_cm\_deployment\_name | Deployment name | `string` | `"graphdb"` | no |
 | project\_id | Project in which the VM will be created | `string` | n/a | yes |
 | zone | The zone where the VM will be created | `string` | `"us-central1-a"` | no |

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -51,7 +51,7 @@ spec:
       - name: source_image
         description: Defines the VM image passed from the GCP Marketplace
         varType: string
-        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-10-8-8-202506050741
+        defaultValue: projects/graphdb-public/global/images/ontotext-graphdb-10-8-9-202507160729
       - name: zone
         description: The zone where the VM will be created
         varType: string

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "source_image" {
   type        = string
   # Set the default value to your image. Marketplace will overwrite this value
   # to a Marketplace owned image on publishing the product
-  default = "projects/graphdb-public/global/images/ontotext-graphdb-10-8-8-202506050741"
+  default = "projects/graphdb-public/global/images/ontotext-graphdb-10-8-9-202507160729"
 }
 
 variable "goog_cm_deployment_name" {


### PR DESCRIPTION
- Updated the default GraphDB version to 10.8.9
- Updated the Terraform to version 0.2.8
